### PR TITLE
Fix asyncio run usage in stealth features

### DIFF
--- a/app/scrapers/selenium_scraper.py
+++ b/app/scrapers/selenium_scraper.py
@@ -212,10 +212,14 @@ class SeleniumScraper(BaseScraper):
 
     def _apply_stealth_features(self):
         """Apply stealth features to the Selenium driver"""
+        if not self.driver:
+            self.logger.warning("Driver not initialized, skipping stealth features")
+            return
+            
         try:
             # Inject stealth scripts
             js_bypass_manager = get_js_bypass_manager()
-            stealth_scripts = asyncio.run(js_bypass_manager.get_stealth_scripts())
+            stealth_scripts = js_bypass_manager.get_stealth_scripts()
 
             for script in stealth_scripts:
                 try:

--- a/app/utils/stealth_manager.py
+++ b/app/utils/stealth_manager.py
@@ -412,12 +412,11 @@ class JSBypassManager:
     ]
 
     def __init__(self):
-        self._lock = asyncio.Lock()
+        pass
 
-    async def get_stealth_scripts(self) -> List[str]:
+    def get_stealth_scripts(self) -> List[str]:
         """Get JavaScript scripts for stealth mode"""
-        async with self._lock:
-            return self.STEALTH_SCRIPTS.copy()
+        return self.STEALTH_SCRIPTS.copy()
 
     async def inject_stealth_scripts(self, driver):
         """Inject stealth scripts into a Selenium driver"""

--- a/docs/tasks/phase3/bugs_fixed.md
+++ b/docs/tasks/phase3/bugs_fixed.md
@@ -1,0 +1,49 @@
+# Bugs Fixed - Phase 3
+
+## Bug Fix #1: AsyncIO Threading Issue in Selenium Scraper
+
+### Problem Description
+The `_apply_stealth_features` method in `app/scrapers/selenium_scraper.py` incorrectly called `asyncio.run(js_bypass_manager.get_stealth_scripts())` within a `ThreadPoolExecutor` context. This anti-pattern can lead to `RuntimeError` or unexpected behavior as it attempts to create a new event loop in a thread that is already managed by asyncio.
+
+### Root Cause
+- The `get_stealth_scripts()` method was unnecessarily async
+- Using `asyncio.run()` inside a thread pool executor that's part of an existing asyncio application
+- The async lock was protecting a simple read operation of a static list
+
+### Solution
+Made the `get_stealth_scripts()` method synchronous since it only returns a copy of a static list of JavaScript strings.
+
+### Files Modified
+- `app/utils/stealth_manager.py`: Lines 414-420
+- `app/scrapers/selenium_scraper.py`: Lines 217-219
+
+### Changes Made
+
+**In `app/utils/stealth_manager.py`:**
+- Changed `get_stealth_scripts()` from async to synchronous
+- Removed unnecessary async lock (`self._lock`)
+- Simplified `__init__` method
+
+**In `app/scrapers/selenium_scraper.py`:**
+- Removed `asyncio.run()` call
+- Added safety check for driver initialization
+- Direct synchronous call to `js_bypass_manager.get_stealth_scripts()`
+
+### Code Changes
+```python
+# Before (problematic):
+stealth_scripts = asyncio.run(js_bypass_manager.get_stealth_scripts())
+
+# After (fixed):
+stealth_scripts = js_bypass_manager.get_stealth_scripts()
+```
+
+### Impact
+- Eliminates potential `RuntimeError` from event loop conflicts
+- Improves performance by removing unnecessary async overhead
+- Maintains thread safety without blocking async operations
+- Code is now properly compatible with ThreadPoolExecutor usage
+
+### Testing
+- Both modified files compile successfully without syntax errors
+- No other code dependencies affected (only one caller of the method)


### PR DESCRIPTION
Make `get_stealth_scripts` synchronous and remove `asyncio.run()` call to prevent `RuntimeError` from nested event loops in `ThreadPoolExecutor`.